### PR TITLE
Add a replace() for removing query strings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ const convertBreadcrumb = string => {
     .replace(/oe/g, 'ö')
     .replace(/ae/g, 'ä')
     .replace(/ue/g, 'ü')
+    .replace(/\?.*/, '')
     .toUpperCase();
 };
 


### PR DESCRIPTION
Think the package is great - but wanted to cater for query strings.
Added  `.replace(/\?.*/, '')` to the breadcrumb conversion script.

It removes any query strings from the breadcrumbs - makes them cleaner.