### PR TITLE
Feature/custom label mapper

### DIFF
--- a/example/pages/nested/customizelabel.js
+++ b/example/pages/nested/customizelabel.js
@@ -1,0 +1,15 @@
+import React from 'react'
+
+import Breadcrumbs from '../../../dist/index.modern'
+
+// Customize label name
+const customMapper = {
+  nested: 'Labels',
+  customizelabel: 'Changed.'
+}
+
+const App = () => {
+  return <Breadcrumbs useDefaultStyle={true} labelMapper={customMapper} />
+}
+
+export default App

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,7 +16,11 @@ import './styles.css';
 const convertBreadcrumb = (
   title: string,
   upperLabel: boolean | undefined,
+  customMapper: LabelMapDictionary | null | undefined,
 ): string => {
+  if (!!customMapper && customMapper[title]) {
+    title = customMapper[title];
+  }
   title = title
     .replace(/-/g, ' ')
     .replace(/oe/g, 'ö')
@@ -35,6 +39,10 @@ interface Breadcrumb {
 
   /** The URL which the breadcrumb points to. Example: 'blog/blog-entries' */
   href: string;
+}
+
+interface LabelMapDictionary {
+  [beforeConvert: string]: string;
 }
 
 interface BreadcrumbsProps {
@@ -70,6 +78,9 @@ interface BreadcrumbsProps {
   /** Classes to be used for the active breadcrumb list item */
   activeItemClassName?: string;
 
+  /** Mapper for customizing the labels that appear in the breadcrumbs */
+  labelMapper?: LabelMapDictionary | null;
+
   /** If true, the label will be displayed on the upper case */
   upperLabel?: boolean;
 }
@@ -85,6 +96,7 @@ const defaultProps: BreadcrumbsProps = {
   inactiveItemClassName: '',
   activeItemStyle: null,
   activeItemClassName: '',
+  labelMapper: null,
   upperLabel: true,
 };
 
@@ -112,6 +124,7 @@ const Breadcrumbs = ({
   inactiveItemClassName,
   activeItemStyle,
   activeItemClassName,
+  labelMapper,
   upperLabel,
 }: BreadcrumbsProps) => {
   const router = useRouter();
@@ -123,7 +136,10 @@ const Breadcrumbs = ({
       linkPath.shift();
 
       const pathArray = linkPath.map((path, i) => {
-        return { breadcrumb: path, href: '/' + linkPath.slice(0, i + 1).join('/') };
+        return {
+          breadcrumb: path,
+          href: '/' + linkPath.slice(0, i + 1).join('/'),
+        };
       });
 
       setBreadcrumbs(pathArray);
@@ -155,7 +171,7 @@ const Breadcrumbs = ({
                 }
                 style={i === breadcrumbs.length - 1 ? activeItemStyle : inactiveItemStyle}>
                 <Link href={breadcrumb.href}>
-                  <a>{convertBreadcrumb(breadcrumb.breadcrumb, upperLabel)}</a>
+                  <a>{convertBreadcrumb(breadcrumb.breadcrumb, upperLabel, labelMapper)}</a>
                 </Link>
               </li>
             );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,14 +13,20 @@ import './styles.css';
  * @returns The transformed title
  *
  */
-const convertBreadcrumb = (title: string): string => {
-  return title
+const convertBreadcrumb = (
+  title: string,
+  upperLabel: boolean | undefined,
+): string => {
+  title = title
     .replace(/-/g, ' ')
     .replace(/oe/g, 'ö')
     .replace(/ae/g, 'ä')
     .replace(/ue/g, 'ü')
-    .replace(/\?.*/, '')
-    .toUpperCase();
+    .replace(/\?.*/, '');
+  if (upperLabel) {
+    title = title.toUpperCase();
+  }
+  return title;
 };
 
 interface Breadcrumb {
@@ -63,6 +69,9 @@ interface BreadcrumbsProps {
 
   /** Classes to be used for the active breadcrumb list item */
   activeItemClassName?: string;
+
+  /** If true, the label will be displayed on the upper case */
+  upperLabel?: boolean;
 }
 
 const defaultProps: BreadcrumbsProps = {
@@ -76,6 +85,7 @@ const defaultProps: BreadcrumbsProps = {
   inactiveItemClassName: '',
   activeItemStyle: null,
   activeItemClassName: '',
+  upperLabel: true,
 };
 
 /**
@@ -102,6 +112,7 @@ const Breadcrumbs = ({
   inactiveItemClassName,
   activeItemStyle,
   activeItemClassName,
+  upperLabel,
 }: BreadcrumbsProps) => {
   const router = useRouter();
   const [breadcrumbs, setBreadcrumbs] = useState<Array<Breadcrumb> | null>(null);
@@ -144,7 +155,7 @@ const Breadcrumbs = ({
                 }
                 style={i === breadcrumbs.length - 1 ? activeItemStyle : inactiveItemStyle}>
                 <Link href={breadcrumb.href}>
-                  <a>{convertBreadcrumb(breadcrumb.breadcrumb)}</a>
+                  <a>{convertBreadcrumb(breadcrumb.breadcrumb, upperLabel)}</a>
                 </Link>
               </li>
             );


### PR DESCRIPTION
In my Project, I have needed to customize label text such
page URL : `/items/{id} ` 
required breadcrumb :  Item List  > `{name of item} `

So, I add `customMapper` prop for convert pathstring to customized string. 
I also wrote example page `/nested/customizelabel` in `/example`  for explain usage.