### PR TITLE
Fix omitIndexList with zero

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -216,7 +216,7 @@ const Breadcrumbs = ({
             if (
               !breadcrumb ||
               breadcrumb.breadcrumb.length === 0 ||
-              (omitIndexList && omitIndexList.find((value) => value === i))
+              (omitIndexList && omitIndexList.includes(i))
             ) {
               return;
             }


### PR DESCRIPTION
Adding `0` to `omitIndexList` doesn't work, because the condition is using `find()` which returns the found element. `0` is a falsy value, so the condition is not satisfied even though it should. Using `includes()` instead fixes this.