### PR TITLE
First replaceCharacterList, then transformLabel

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -31,11 +31,7 @@ const convertBreadcrumb = (
   transformLabel?: ((title: string) => React.ReactNode) | undefined
 ): React.ReactNode => {
   let transformedTitle = getPathFromUrl(title);
-
-  if (transformLabel) {
-    return transformLabel(transformedTitle);
-  }
-
+  
   if (replaceCharacterList) {
     for (let i = 0; i < replaceCharacterList.length; i++) {
       transformedTitle = transformedTitle.replaceAll(
@@ -43,6 +39,10 @@ const convertBreadcrumb = (
         replaceCharacterList[i].to
       );
     }
+  }
+
+  if (transformLabel) {
+    return transformLabel(transformedTitle);
   }
 
   // decode for utf-8 characters and return ascii. 


### PR DESCRIPTION
When we use transformLabel together with replaceCharacterList, we don't reach the replaceCharacterList condition, because we return the result of transformLabel function. In order to use them together, I moved replaceCharacterList to the beginning. This way they can work together.