### PR TITLE
DecodeURIComponent on breadcrumb label to avoid non ascii char display issue

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -174,7 +174,7 @@ const Breadcrumbs = ({
 
       const pathArray = linkPath.map((path, i) => {
         return {
-          breadcrumb: path,
+          breadcrumb: decodeURIComponent(path),
           href: '/' + linkPath.slice(0, i + 1).join('/'),
         };
       });


### PR DESCRIPTION
Added decodeURIComponent on router paths to avoid non ascii char display issue, e.g. route like "/rhône" looks like "Rh%C3%B4ne" in breadcrumb.